### PR TITLE
adding datasources and changing record id

### DIFF
--- a/flights/NCRIC_descriptors_flight.yaml
+++ b/flights/NCRIC_descriptors_flight.yaml
@@ -1,9 +1,7 @@
-# Query for data from vpn: "SELECT d.*, boss3.red_vrm as red_vrm, boss3.red_id as red_id FROM dbo.BrianMantisLabels as d LEFT JOIN (SELECT si.ste_ID AS siteid, si.ste_Name AS sitename, si.ste_Description AS sitedescr, so.src_ID AS sourceid, so.src_Name AS sourcename, so.src_Fixed AS fixedmobile, so.src_Description AS srcdescr, r.red_ID AS red_id, r.red_VRM AS red_vrm, r.red_TimeStamp AS date, r.red_Misread AS red_misread, r.red_ManualEntry AS red_manualentry, ms.msp_usr_ID AS msp_userid,  r.red_src_ID AS red_sourceid FROM dbo.Reads AS r INNER JOIN dbo.Sources AS so ON so.src_ID = r.red_src_ID INNER JOIN dbo.Sites AS si ON si.ste_ID = so.src_ste_ID LEFT OUTER JOIN dbo.MobileSpatial AS ms ON r.red_ID = ms.msp_red_ID) as boss3 on boss3.red_vrm= d.Plate AND boss3.date=d.TimeStamp;"
-# Query for sample dataset from atlas: "SELECT \"d\".*, \"b\".\"red_vrm\" as \"red_vrm\", \"b\".\"red_id\" as \"red_id\" FROM boss3_21_descriptors as \"d\" LEFT JOIN boss3data21_aug2018_top200k as \"b\" ON (\"b\".\"red_vrm\"=\"d\".\"Plate\") AND (\"TimeStamp\"=\"date\") WHERE \"TimeStamp\" >= '2018-08-01' AND \"TimeStamp\" <='2018-09-01' AND \"red_id\" is not null AND \"red_vrm\"<>'CAUTION'" 
+# final query: select * from boss3_21_descriptors_10minutes_oct2_appending;
+   # not using confidencemetrics (LabelConfidence in Descriptors view dataset) so then 2 entities and 1 association.
 
-# for recurring integrations: "select d.*, boss3.red_vrm, boss3.red_id from boss3_21_descriptors_10minutes as d left join boss3_21_from2019sept10_all as boss3 on boss3.red_vrm = d.Plate and boss3.date=d.TimeStamp;"
 
-#not using confidencemetrics (LabelConfidence in Descriptors view dataset) so then 2 entities and 1 association.
 
 entityDefinitions:
   vehicles:
@@ -16,17 +14,29 @@ entityDefinitions:
       vehicle.licensenumber:
         type: "vehicle.licensenumber"
         column: "Plate"
+      ol.datasource:            
+        type: "ol.datasource"
+        transforms:
+        - !<transforms.ValueTransform>
+          value: "BOSS3"
     name: "vehicles"
 
-#record that merges with the rest of the data from a particular "read" in BOSS3.
+## Pk was originally red_id to match BOSS3 flight code and merge with the rest of the data from a particular "read" in BOSS3.
+# but hard to match the plate to a particular red_id (could be several or none) so making pk unique in itself here and among dbs, using what's in this table only.
   vehiclerecords1:
     fqn: "ol.vehicle"
     entitySetName: "NCRICVehicleRecords"
     propertyDefinitions:
       ol.id:
         type: "ol.id" 
-        # changed from Plate to red_id to match BOSS3 flight code. 
-        column: "red_id"
+        transforms:
+        - !<transforms.ConcatCombineTransform>
+          separator: "_"
+          transforms:
+          - !<transforms.ColumnTransform>
+            column: "Plate"
+          - !<transforms.ValueTransform>
+            value: "labels"
       vehicle.licensenumber:
         type: "vehicle.licensenumber"
         column: "Plate"
@@ -113,107 +123,108 @@ entityDefinitions:
           value: "BOSS3"
     name: "vehiclerecords1"
 
-#record that is separate from the rest of the data from a particular "read". Different pk. Repeat info.
+# Not integrating - hard to join with records spread among tables, and not necessary.
+# A record that was separate from the rest of the data from a particular "read". Different pk. Repeat info.
 # added "_labels" suffix to red_id. 
-  vehiclerecords2:
-    fqn: "ol.vehicle"
-    entitySetName: "NCRICVehicleRecords"
-    propertyDefinitions:
-      ol.id:
-        type: "ol.id" 
-        transforms:
-        - !<transforms.ConcatCombineTransform>
-          separator: "-"
-          transforms:
-          - !<transforms.ColumnTransform>
-            column: "red_id"
-          - !<transforms.ValueTransform>
-            value: "labels"
-      vehicle.licensenumber:
-        type: "vehicle.licensenumber"
-        column: "Plate"
-      ol.datelogged:
-        type: "ol.datelogged"
-        column: "TimeStamp"
-        transforms:
-        - !<transforms.DateTimeTransform>
-          pattern: ["yyyy-MM-dd HH:mm:ss.S","yyyy-MM-dd HH:mm:ss.SS","yyyy-MM-dd HH:mm:ss.SSS"]
-          timezone: "America/Los Angeles"
-      vehicle.make:
-        type: "vehicle.make"
-        transforms:
-        - !<transforms.BooleanRegexTransform>
-          column: "LabelName"
-          pattern: "(?i)(acura|audi|bmw|buick|cadillac|chevy|chrysler|dodge|fiat|ford|gmc|honda|hyundai|infinity|jeep|kia|lexus|lincoln|mazda|mercedes|mercury|(\\bmini\\b)|mitsubishi|nissan|pontiac|scion|subaru|suzuki|tesla|toyota|volvo|vw)"
-          transformsIfTrue:
-          - !<transforms.ConcatCombineTransform>
-            separator: "-"
-            transforms:
-            - !<transforms.SplitTransform>
-              column: "LabelName"
-              separator: "-"
-              index: 0
-      vehicle.model:
-        type: "vehicle.model"
-        transforms:
-        - !<transforms.BooleanRegexTransform>
-          column: "LabelName"
-          pattern: "(?i)(ford-mustang-gt|ford-mustang)" 
-          transformsIfTrue:      ## we only want the mustang gt words, and not the "ford".
-          - !<transforms.ConcatCombineTransform>
-            separator: "-"
-            transforms:
-            - !<transforms.SplitTransform>
-              column: "LabelName"
-              separator: "-"
-              index: 1
-            - !<transforms.SplitTransform>
-              column: "LabelName"
-              separator: "-"
-              index: 2
-              ifMoreThan: 2
-      vehicle.color:
-        type: "vehicle.color"
-        transforms:
-        - !<transforms.BooleanRegexTransform>
-          column: "LabelName"
-          pattern: "(?i)(blue|dark|green|light|red|white|yellow)"
-          transformsIfTrue:
-          - !<transforms.ColumnTransform>
-            column: "LabelName"
-      ol.accessories:
-        type: "ol.accessories"
-        transforms:
-        - !<transforms.BooleanRegexTransform>
-          column: "LabelName"
-          pattern: "(?i)(spare tire|paper-plate|pedestal-spoiler|ca-clean-air-vehicle-sticker|rectangular-sticker|uber-sticker|roof-rack|pickup-ladder-rack|racing-strip)"
-          transformsIfTrue:
-          - !<transforms.ColumnTransform>
-            column: "LabelName"
-      vehicle.style:
-        type: "vehicle.style"
-        transforms:
-        - !<transforms.BooleanRegexTransform>
-          column: "LabelName"
-          pattern: "(?i)(box-truck|full-size-van|other-truck|car|pickup|minivan|hatchback|sedan|SUV)"
-          transformsIfTrue:
-          - !<transforms.ColumnTransform>
-            column: "LabelName"
-      ol.label:
-        type: "ol.label"
-        transforms:
-        - !<transforms.BooleanRegexTransform>
-          column: "LabelName"
-          pattern: "(?i)(night|day)"
-          transformsIfTrue:
-          - !<transforms.ColumnTransform>
-            column: "LabelName"
-      ol.datasource:
-        type: "ol.datasource"
-        transforms:
-        - !<transforms.ValueTransform>
-          value: "BOSS3"
-    name: "vehiclerecords2"
+  # vehiclerecords2:
+  #   fqn: "ol.vehicle"
+  #   entitySetName: "NCRICVehicleRecords"
+  #   propertyDefinitions:
+  #     ol.id:
+  #       type: "ol.id" 
+  #       transforms:
+  #       - !<transforms.ConcatCombineTransform>
+  #         separator: "-"
+  #         transforms:
+  #         - !<transforms.ColumnTransform>
+  #           column: "red_id"
+  #         - !<transforms.ValueTransform>
+  #           value: "labels"
+  #     vehicle.licensenumber:
+  #       type: "vehicle.licensenumber"
+  #       column: "Plate"
+  #     ol.datelogged:
+  #       type: "ol.datelogged"
+  #       column: "TimeStamp"
+  #       transforms:
+  #       - !<transforms.DateTimeTransform>
+  #         pattern: ["yyyy-MM-dd HH:mm:ss.S","yyyy-MM-dd HH:mm:ss.SS","yyyy-MM-dd HH:mm:ss.SSS"]
+  #         timezone: "America/Los Angeles"
+  #     vehicle.make:
+  #       type: "vehicle.make"
+  #       transforms:
+  #       - !<transforms.BooleanRegexTransform>
+  #         column: "LabelName"
+  #         pattern: "(?i)(acura|audi|bmw|buick|cadillac|chevy|chrysler|dodge|fiat|ford|gmc|honda|hyundai|infinity|jeep|kia|lexus|lincoln|mazda|mercedes|mercury|(\\bmini\\b)|mitsubishi|nissan|pontiac|scion|subaru|suzuki|tesla|toyota|volvo|vw)"
+  #         transformsIfTrue:
+  #         - !<transforms.ConcatCombineTransform>
+  #           separator: "-"
+  #           transforms:
+  #           - !<transforms.SplitTransform>
+  #             column: "LabelName"
+  #             separator: "-"
+  #             index: 0
+  #     vehicle.model:
+  #       type: "vehicle.model"
+  #       transforms:
+  #       - !<transforms.BooleanRegexTransform>
+  #         column: "LabelName"
+  #         pattern: "(?i)(ford-mustang-gt|ford-mustang)" 
+  #         transformsIfTrue:      ## we only want the mustang gt words, and not the "ford".
+  #         - !<transforms.ConcatCombineTransform>
+  #           separator: "-"
+  #           transforms:
+  #           - !<transforms.SplitTransform>
+  #             column: "LabelName"
+  #             separator: "-"
+  #             index: 1
+  #           - !<transforms.SplitTransform>
+  #             column: "LabelName"
+  #             separator: "-"
+  #             index: 2
+  #             ifMoreThan: 2
+  #     vehicle.color:
+  #       type: "vehicle.color"
+  #       transforms:
+  #       - !<transforms.BooleanRegexTransform>
+  #         column: "LabelName"
+  #         pattern: "(?i)(blue|dark|green|light|red|white|yellow)"
+  #         transformsIfTrue:
+  #         - !<transforms.ColumnTransform>
+  #           column: "LabelName"
+  #     ol.accessories:
+  #       type: "ol.accessories"
+  #       transforms:
+  #       - !<transforms.BooleanRegexTransform>
+  #         column: "LabelName"
+  #         pattern: "(?i)(spare tire|paper-plate|pedestal-spoiler|ca-clean-air-vehicle-sticker|rectangular-sticker|uber-sticker|roof-rack|pickup-ladder-rack|racing-strip)"
+  #         transformsIfTrue:
+  #         - !<transforms.ColumnTransform>
+  #           column: "LabelName"
+  #     vehicle.style:
+  #       type: "vehicle.style"
+  #       transforms:
+  #       - !<transforms.BooleanRegexTransform>
+  #         column: "LabelName"
+  #         pattern: "(?i)(box-truck|full-size-van|other-truck|car|pickup|minivan|hatchback|sedan|SUV)"
+  #         transformsIfTrue:
+  #         - !<transforms.ColumnTransform>
+  #           column: "LabelName"
+  #     ol.label:
+  #       type: "ol.label"
+  #       transforms:
+  #       - !<transforms.BooleanRegexTransform>
+  #         column: "LabelName"
+  #         pattern: "(?i)(night|day)"
+  #         transformsIfTrue:
+  #         - !<transforms.ColumnTransform>
+  #           column: "LabelName"
+  #     ol.datasource:
+  #       type: "ol.datasource"
+  #       transforms:
+  #       - !<transforms.ValueTransform>
+  #         value: "BOSS3"
+  #   name: "vehiclerecords2"
 
 
 associationDefinitions:
@@ -226,26 +237,32 @@ associationDefinitions:
       ol.id:
         type: "ol.id"
         transforms:
-        - !<transforms.ConcatTransform>
-          columns: ["Plate", "red_id"]
-          separator: "_"
-    name: "has1"
-  has2:
-    fqn: "ol.has"
-    entitySetName: "NCRICHas"
-    src: "vehicles"
-    dst: "vehiclerecords2"
-    propertyDefinitions:
-      ol.id:
-        type: "ol.id"
-        transforms:
         - !<transforms.ConcatCombineTransform>
-          separator: "-"
+          separator: "_"
           transforms:
           - !<transforms.ColumnTransform>
             column: "Plate"
-          - !<transforms.ColumnTransform>
-            column: "red_id"
           - !<transforms.ValueTransform>
             value: "labels"
-    name: "has2"
+          - !<transforms.ColumnTransform>
+            column: "TimeStamp"
+    name: "has1"
+  # has2:
+  #   fqn: "ol.has"
+  #   entitySetName: "NCRICHas"
+  #   src: "vehicles"
+  #   dst: "vehiclerecords2"
+  #   propertyDefinitions:
+  #     ol.id:
+  #       type: "ol.id"
+  #       transforms:
+  #       - !<transforms.ConcatCombineTransform>
+  #         separator: "-"
+  #         transforms:
+  #         - !<transforms.ColumnTransform>
+  #           column: "Plate"
+  #         - !<transforms.ColumnTransform>
+  #           column: "red_id"
+  #         - !<transforms.ValueTransform>
+  #           value: "labels"
+  #   name: "has2"


### PR DESCRIPTION
Added datasource to vehicle record and vehicle (BOSS3), and made the recordID "plate + "_labels" ". This won't merge records with those from other flights, but that is okay. Before the recordID was "red_id" in an attempt to reconstitute full records (labels + other info) from the other boss3 flights. But not working since boss3 records are distributed in > 1 table (would have to join atlas tables while integrating). 