### PR TITLE
Fix/timezones

### DIFF
--- a/flights/ncric_v5alpr_historical_flight.yaml
+++ b/flights/ncric_v5alpr_historical_flight.yaml
@@ -53,18 +53,18 @@ entityDefinitions:
         column: "lprTimeStamp"
         transforms:
         - !<transforms.DateTimeTransform>
-          pattern: ["yyyy-MM-dd HH:mm:ss.SSS +00:00"]
-          # timezone: "America/Los_Angeles"
-      # ol.locationcoordinates:
-      #   type: "ol.locationcoordinates"
-      #   transforms:
-      #   - !<transforms.GeographyPointTransform>
-      #     latTransforms:
-      #     - !<transforms.ColumnTransform>
-      #       column: "gpsLat"
-      #     lonTransforms:
-      #     - !<transforms.ColumnTransform>
-      #       column: "gpsLng"
+          pattern: ["yyyy-MM-dd HH:mm:ss.SSS XXX"]
+          timezone: "UTC"
+      ol.locationcoordinates:
+        type: "ol.locationcoordinates"
+        transforms:
+        - !<transforms.GeographyPointTransform>
+          latTransforms:
+          - !<transforms.ColumnTransform>
+            column: "gpsLat"
+          lonTransforms:
+          - !<transforms.ColumnTransform>
+            column: "gpsLng"
       publicsafety.agencyname:
         type: "publicsafety.agencyname"
         column: "lprSourceId"
@@ -111,16 +111,16 @@ entityDefinitions:
         transforms:
         - !<transforms.ConcatTransform>
           columns: ["gpsLat","gpsLng"]
-      # ol.locationcoordinates:
-      #   type: "ol.locationcoordinates"
-      #   transforms:
-      #   - !<transforms.GeographyPointTransform>
-      #     latTransforms:
-      #     - !<transforms.ColumnTransform>
-      #       column: "gpsLat"
-      #     lonTransforms:
-      #     - !<transforms.ColumnTransform>
-      #       column: "gpsLng" 
+      ol.locationcoordinates:
+        type: "ol.locationcoordinates"
+        transforms:
+        - !<transforms.GeographyPointTransform>
+          latTransforms:
+          - !<transforms.ColumnTransform>
+            column: "gpsLat"
+          lonTransforms:
+          - !<transforms.ColumnTransform>
+            column: "gpsLng" 
     name: "locations"
 
   agencies:
@@ -200,8 +200,8 @@ associationDefinitions:
         column: "lprTimeStamp"
         transforms:
         - !<transforms.DateTimeTransform>
-          pattern: ["yyyy-MM-dd HH:mm:ss.SSS +00:00"]
-          # timezone: "America/Los_Angeles"
+          pattern: ["yyyy-MM-dd HH:mm:ss.SSS XXX"]
+          timezone: "UTC"
       general.stringid:
         type: "general.stringid"
         transforms:
@@ -228,8 +228,8 @@ associationDefinitions:
         column: "lprTimeStamp"
         transforms:
         - !<transforms.DateTimeTransform>
-          pattern: ["yyyy-MM-dd HH:mm:ss.SSS +00:00"]
-          # timezone: "America/Los_Angeles"
+          pattern: ["yyyy-MM-dd HH:mm:ss.SSS XXX"]
+          timezone: "UTC"
       general.stringid:
         type: "general.stringid"
         transforms:
@@ -268,8 +268,8 @@ associationDefinitions:
         column: "lprTimeStamp"
         transforms:
         - !<transforms.DateTimeTransform>
-          pattern: ["yyyy-MM-dd HH:mm:ss.SSS +00:00"]
-          # timezone: "America/Los_Angeles"
+          pattern: ["yyyy-MM-dd HH:mm:ss.SSS XXX"]
+          timezone: "UTC"
     name: "includes1"
 
   includes2:
@@ -296,8 +296,8 @@ associationDefinitions:
         column: "lprTimeStamp"
         transforms:
         - !<transforms.DateTimeTransform>
-          pattern: ["yyyy-MM-dd HH:mm:ss.SSS +00:00"]
-          # timezone: "America/Los_Angeles"
+          pattern: ["yyyy-MM-dd HH:mm:ss.SSS XXX"]
+          timezone: "UTC"
     name: "includes2"
 
   locatedat1:

--- a/flights/ncric_v5alpr_historical_flight.yaml
+++ b/flights/ncric_v5alpr_historical_flight.yaml
@@ -1,9 +1,7 @@
 # sql query in psql: select * from v5plates where "lprTimeStamp" >= '2018-08-01' AND "lprTimeStamp" <= '2018-09-01' limit 5000 ;
-# sql query for sample in intellij: "select * from v5plates where \"lprTimeStamp\" >= '2018-08-01' AND \"lprTimeStamp\" <= '2018-09-01' limit 5000"
-# historical sql query in intellij: "select * from v5plates_all where \"lprTimeStamp\" <= current_timestamp order by \"id\";" 
+# historical sql query in intellij: "select * from v5plates_all where \"lprTimeStamp\" >= '2019-02-05' AND to_timestamp(\"lprTimeStamp\",'YYYY-MM-DD HH24.MI.SS.MS' ) <= current_timestamp order by \"id\";" 
 
-# [red_id, sourceid, siteid] will get a suffix added to prevent name collisions from BOSS3 and SCSO
-
+# [red_id, sourceid, siteid] will get a suffix added to prevent name collisions from OSS3 and SCSO
 # taking out alerts, there's no info in them but an ID, so every read would have one. Meaningless. Also v5alertId is not unique.
 
 entityDefinitions:

--- a/flights/ncric_v5alpr_historical_flight.yaml
+++ b/flights/ncric_v5alpr_historical_flight.yaml
@@ -43,9 +43,9 @@ entityDefinitions:
       vehicle.licensestate:
         type: "vehicle.licensestate"
         column: "lpState"
-      # ol.licenseplateimage:
-      #   type: "ol.licenseplateimage"
-      #   column: "lprPicture"
+      ol.licenseplateimage:
+        type: "ol.licenseplateimage"
+        column: "lprPicture"
       ol.datelogged:
         type: "ol.datelogged"
         column: "lprTimeStamp"

--- a/flights/ncric_v5alpr_recurring_flight.yaml
+++ b/flights/ncric_v5alpr_recurring_flight.yaml
@@ -2,7 +2,7 @@
 # sql query for sample in intellij: "select * from v5plates where \"lprTimeStamp\" >= '2018-08-01' AND \"lprTimeStamp\" <= '2018-09-01' limit 5000"
 # historical sql query in intellij: "select * from v5plates_all where \"lprTimeStamp\" <= current_timestamp order by \"id\";" 
 
-# [red_id, sourceid, siteid] will get a suffix added to prevent name collisions from BOSS3 and SCSO
+# [red_id, sourceid, siteid] will get a suffiZ added to prevent name collisions from BOSS3 and SCSO
 
 # taking out alerts, there's no info in them but an ID, so every read would have one. Meaningless. Also v5alertId is not unique.
 
@@ -45,16 +45,16 @@ entityDefinitions:
       vehicle.licensestate:
         type: "vehicle.licensestate"
         column: "lpstate"
-      ol.licenseplateimage:
-        type: "ol.licenseplateimage"
-        column: "lprpicture"
+      # ol.licenseplateimage:
+      #   type: "ol.licenseplateimage"
+      #   column: "lprpicture"
       ol.datelogged:
         type: "ol.datelogged"
         column: "lprtimestamp"
-        transforms:
-        - !<transforms.DateTimeTransform>
-          pattern: ["yyyy-MM-dd HH:mm:ss.SSS +00:00"]
-          # timezone: "America/Los_Angeles"
+        # transforms:
+        # - !<transforms.DateTimeTransform>
+        #   pattern: ["yyyy-MM-dd HH:mm:ss.SSS"]
+        #   timezone: "UTC"
       ol.locationcoordinates:
         type: "ol.locationcoordinates"
         transforms:
@@ -202,16 +202,16 @@ entityDefinitions:
       vehicle.licensestate:
         type: "vehicle.licensestate"
         column: "lpstate"
-      ol.licenseplateimage:
-        type: "ol.licenseplateimage"
-        column: "lprpicture"
+      # ol.licenseplateimage:
+      #   type: "ol.licenseplateimage"
+      #   column: "lprpicture"
       ol.datelogged:
         type: "ol.datelogged"
         column: "lprtimestamp"
-        transforms:
-        - !<transforms.DateTimeTransform>
-          pattern: ["yyyy-MM-dd HH:mm:ss.SSS +00:00"]
-          # timezone: "America/Los_Angeles"
+        # transforms:
+        # - !<transforms.DateTimeTransform>
+        #   pattern: ["yyyy-MM-dd HH:mm:ss.SSS"]
+        #   timezone: "UTC"
       ol.locationcoordinates:
         type: "ol.locationcoordinates"
         transforms:
@@ -319,7 +319,7 @@ entityDefinitions:
         transforms:
         - !<transforms.ValueTransform>
           value: "V5"    
-    name: "confidencemetricsv5"
+    name: "confidencemetrics2"
 
 
 
@@ -354,11 +354,11 @@ associationDefinitions:
     propertyDefinitions:
       ol.datelogged:
         type: "ol.datelogged"
-        column: "lprtimestamp"
-        transforms:
-        - !<transforms.DateTimeTransform>
-          pattern: ["yyyy-MM-dd HH:mm:ss.SSS +00:00"]
-          # timezone: "America/Los Angeles"
+        # column: "lprtimestamp"
+        # transforms:
+        # - !<transforms.DateTimeTransform>
+        #   pattern: ["yyyy-MM-dd HH:mm:ss.SSS"]
+        #   timezone: "UTC"
       general.stringid:
         type: "general.stringid"
         transforms:
@@ -382,10 +382,10 @@ associationDefinitions:
       ol.datelogged:
         type: "ol.datelogged"
         column: "lprtimestamp"
-        transforms:
-        - !<transforms.DateTimeTransform>
-          pattern: ["yyyy-MM-dd HH:mm:ss.SSS +00:00"]
-          # timezone: "America/Los_Angeles"
+        # transforms:
+        # - !<transforms.DateTimeTransform>
+        #   pattern: ["yyyy-MM-dd HH:mm:ss.SSS"]
+        #   timezone: "UTC"
       general.stringid:
         type: "general.stringid"
         transforms:
@@ -421,10 +421,10 @@ associationDefinitions:
       date.completeddatetime:
         type: "date.completeddatetime"
         column: "lprtimestamp"
-        transforms:
-        - !<transforms.DateTimeTransform>
-          pattern: ["yyyy-MM-dd HH:mm:ss.SSS +00:00"]
-          # timezone: "America/Los_Angeles"
+        # transforms:
+        # - !<transforms.DateTimeTransform>
+        #   pattern: ["yyyy-MM-dd HH:mm:ss.SSS"]
+        #   timezone: "UTC"
     name: "includes1"
 
   includes2:
@@ -448,10 +448,10 @@ associationDefinitions:
       date.completeddatetime:
         type: "date.completeddatetime"
         column: "lprtimestamp"
-        transforms:
-        - !<transforms.DateTimeTransform>
-          pattern: ["yyyy-MM-dd HH:mm:ss.SSS +00:00"]
-          # timezone: "America/Los_Angeles"
+        # transforms:
+        # - !<transforms.DateTimeTransform>
+        #   pattern: ["yyyy-MM-dd HH:mm:ss.SSS"]
+        #   timezone: "UTC"
     name: "includes2"
 
   locatedat1:
@@ -561,10 +561,10 @@ associationDefinitions:
       ol.datelogged:
         type: "ol.datelogged"
         column: "lprtimestamp"
-        transforms:
-        - !<transforms.DateTimeTransform>
-          pattern: ["yyyy-MM-dd HH:mm:ss.SSS +00:00"]
-          # timezone: "America/Los_Angeles"
+        # transforms:
+        # - !<transforms.DateTimeTransform>
+        #   pattern: ["yyyy-MM-dd HH:mm:ss.SSS"]
+        #   timezone: "UTC"
       general.stringid:
         type: "general.stringid"
         transforms:
@@ -588,10 +588,10 @@ associationDefinitions:
       ol.datelogged:
         type: "ol.datelogged"
         column: "lprtimestamp"
-        transforms:
-        - !<transforms.DateTimeTransform>
-          pattern: ["yyyy-MM-dd HH:mm:ss.SSS +00:00"]
-          # timezone: "America/Los_Angeles"
+        # transforms:
+        # - !<transforms.DateTimeTransform>
+        #   pattern: ["yyyy-MM-dd HH:mm:ss.SSS"]
+        #   timezone: "UTC"
       general.stringid:
         type: "general.stringid"
         transforms:
@@ -627,10 +627,10 @@ associationDefinitions:
       date.completeddatetime:
         type: "date.completeddatetime"
         column: "lprtimestamp"
-        transforms:
-        - !<transforms.DateTimeTransform>
-          pattern: ["yyyy-MM-dd HH:mm:ss.SSS +00:00"]
-          # timezone: "America/Los_Angeles"
+        # transforms:
+        # - !<transforms.DateTimeTransform>
+        #   pattern: ["yyyy-MM-dd HH:mm:ss.SSS"]
+        #   timezone: "UTC"
     name: "includes1_2"
 
   includes2_2:
@@ -654,10 +654,10 @@ associationDefinitions:
       date.completeddatetime:
         type: "date.completeddatetime"
         column: "lprtimestamp"
-        transforms:
-        - !<transforms.DateTimeTransform>
-          pattern: ["yyyy-MM-dd HH:mm:ss.SSS +00:00"]
-          # timezone: "America/Los_Angeles"
+        # transforms:
+        # - !<transforms.DateTimeTransform>
+        #   pattern: ["yyyy-MM-dd HH:mm:ss.SSS"]
+        #   timezone: "UTC"
     name: "includes2_2"
 
   locatedat1_2:

--- a/flights/ncric_v5alpr_recurring_flight.yaml
+++ b/flights/ncric_v5alpr_recurring_flight.yaml
@@ -45,9 +45,9 @@ entityDefinitions:
       vehicle.licensestate:
         type: "vehicle.licensestate"
         column: "lpstate"
-      # ol.licenseplateimage:
-      #   type: "ol.licenseplateimage"
-      #   column: "lprpicture"
+      ol.licenseplateimage:
+        type: "ol.licenseplateimage"
+        column: "lprpicture"
       ol.datelogged:
         type: "ol.datelogged"
         column: "lprtimestamp"
@@ -202,9 +202,9 @@ entityDefinitions:
       vehicle.licensestate:
         type: "vehicle.licensestate"
         column: "lpstate"
-      # ol.licenseplateimage:
-      #   type: "ol.licenseplateimage"
-      #   column: "lprpicture"
+      ol.licenseplateimage:
+        type: "ol.licenseplateimage"
+        column: "lprpicture"
       ol.datelogged:
         type: "ol.datelogged"
         column: "lprtimestamp"
@@ -354,7 +354,7 @@ associationDefinitions:
     propertyDefinitions:
       ol.datelogged:
         type: "ol.datelogged"
-        # column: "lprtimestamp"
+        column: "lprtimestamp"
         # transforms:
         # - !<transforms.DateTimeTransform>
         #   pattern: ["yyyy-MM-dd HH:mm:ss.SSS"]


### PR DESCRIPTION
Locally tested timezone integration for new recurring jobs (not yet running) and historical jobs (needs a partial replace for timezone only, in a different DB location). Recurring integrations do not need a datetime parser as they are correctly stored on atlas (timezone data type with offset).